### PR TITLE
Harden MCP startup and map bridge errors to JSON-RPC responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,25 @@ Exposed MCP prompts:
 
 The MCP layer is intentionally thin: it forwards to the bridge command surface and keeps edit approval/safety enforcement inside the existing Visual Studio bridge flow.
 
+Implementation note: the server advertises MCP `tools` capability only. `resources/*` and `prompts/*` methods are still implemented, but not advertised, to avoid eager startup probes from MCP clients that can trigger Visual Studio automation calls before the IDE is fully ready.
+
+Example MCP client registration (Claude Code and Codex CLI use the same stdio command):
+
+```json
+{
+  "mcpServers": {
+    "vs-ide-bridge": {
+      "command": "C:\\path\\to\\vs-ide-bridge.exe",
+      "args": [
+        "mcp-server",
+        "--instance",
+        "<instanceId>"
+      ]
+    }
+  }
+}
+```
+
 ### Pipe protocol
 
 Each request is one JSON object terminated by `\n`:

--- a/src/VsIdeBridgeCli/McpServer.cs
+++ b/src/VsIdeBridgeCli/McpServer.cs
@@ -87,8 +87,6 @@ internal static partial class CliApp
             ["capabilities"] = new JsonObject
             {
                 ["tools"] = new JsonObject(),
-                ["resources"] = new JsonObject(),
-                ["prompts"] = new JsonObject(),
             },
             ["serverInfo"] = new JsonObject
             {
@@ -154,7 +152,7 @@ internal static partial class CliApp
                 _ => throw new McpRequestException(id, -32602, $"Unknown MCP tool: {toolName}"),
             };
 
-            var response = await SendBridgeAsync(options, command, commandArgs).ConfigureAwait(false);
+            var response = await SendBridgeAsync(id, options, command, commandArgs).ConfigureAwait(false);
             return new JsonObject
             {
                 ["content"] = new JsonArray
@@ -190,10 +188,10 @@ internal static partial class CliApp
             var uri = p?["uri"]?.GetValue<string>() ?? throw new McpRequestException(id, -32602, "resources/read missing uri.");
             JsonObject data = uri switch
             {
-                "bridge://current-solution" => await SendBridgeAsync(options, "state", string.Empty).ConfigureAwait(false),
-                "bridge://active-document" => await SendBridgeAsync(options, "state", string.Empty).ConfigureAwait(false),
-                "bridge://open-tabs" => await SendBridgeAsync(options, "list-tabs", string.Empty).ConfigureAwait(false),
-                "bridge://error-list-snapshot" => await SendBridgeAsync(options, "errors", "--quick --wait-for-intellisense false").ConfigureAwait(false),
+                "bridge://current-solution" => await SendBridgeAsync(id, options, "state", string.Empty).ConfigureAwait(false),
+                "bridge://active-document" => await SendBridgeAsync(id, options, "state", string.Empty).ConfigureAwait(false),
+                "bridge://open-tabs" => await SendBridgeAsync(id, options, "list-tabs", string.Empty).ConfigureAwait(false),
+                "bridge://error-list-snapshot" => await SendBridgeAsync(id, options, "errors", "--quick --wait-for-intellisense false").ConfigureAwait(false),
                 _ => throw new McpRequestException(id, -32602, $"Unknown resource uri: {uri}"),
             };
 
@@ -250,19 +248,34 @@ internal static partial class CliApp
             };
         }
 
-        private static async Task<JsonObject> SendBridgeAsync(CliOptions options, string command, string args)
+        private static async Task<JsonObject> SendBridgeAsync(JsonNode? id, CliOptions options, string command, string args)
         {
-            var selector = BridgeInstanceSelector.FromOptions(options);
-            var discovery = await PipeDiscovery.SelectAsync(selector, options.GetFlag("verbose")).ConfigureAwait(false);
-            await using var client = new PipeClient(discovery.PipeName, options.GetInt32("timeout-ms", 10_000));
-            var request = new JsonObject
+            try
             {
-                ["id"] = Guid.NewGuid().ToString("N")[..8],
-                ["command"] = command,
-                ["args"] = args,
-            };
+                var selector = BridgeInstanceSelector.FromOptions(options);
+                var discovery = await PipeDiscovery.SelectAsync(selector, options.GetFlag("verbose")).ConfigureAwait(false);
+                await using var client = new PipeClient(discovery.PipeName, options.GetInt32("timeout-ms", 10_000));
+                var request = new JsonObject
+                {
+                    ["id"] = Guid.NewGuid().ToString("N")[..8],
+                    ["command"] = command,
+                    ["args"] = args,
+                };
 
-            return await client.SendAsync(request).ConfigureAwait(false);
+                return await client.SendAsync(request).ConfigureAwait(false);
+            }
+            catch (CliException ex)
+            {
+                throw new McpRequestException(id, -32001, ex.Message);
+            }
+            catch (TimeoutException ex)
+            {
+                throw new McpRequestException(id, -32002, $"Timed out waiting for Visual Studio bridge response: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                throw new McpRequestException(id, -32003, $"Failed communicating with Visual Studio bridge pipe: {ex.Message}");
+            }
         }
 
         private static string BuildArgs(params (string Name, string? Value)[] items)


### PR DESCRIPTION
### Motivation

- Prevent MCP clients from eagerly probing Visual Studio resources at MCP registration/startup which can trigger automation calls too early and cause crashes.  
- Ensure failures from pipe discovery or bridge unavailability are returned as per-call JSON-RPC errors tied to the original request `id` instead of crashing the MCP server loop.  
- Make the MCP server start cleanly when Visual Studio is not present and fail gracefully for individual calls when the bridge is unavailable.

### Description

- Advertise only the `tools` capability in `initialize` by removing `resources` and `prompts` from the advertised `capabilities` while keeping their handlers implemented to avoid eager startup probes (`InitializeResult`).  
- Change `SendBridgeAsync` signature to accept the MCP request `id` and wrap the bridge dispatch in a `try`/`catch` that converts expected failures into `McpRequestException` with distinct error codes (`CliException` -> `-32001`, `TimeoutException` -> `-32002`, `IOException` -> `-32003`).  
- Propagate the request `id` from MCP call sites by updating calls in `CallToolAsync` and `ReadResourceAsync` to call `SendBridgeAsync(id, ...)` so per-call failures return JSON-RPC errors tied to the original request.  
- Document the behavior and include an MCP client registration example in `README.md` explaining that only `tools` are advertised to avoid startup probes and showing how to register the stdio MCP server for both Claude Code and Codex CLI.

### Testing

- Ran pattern checks (`rg`) to verify all `SendBridgeAsync` call sites now pass the MCP `id` and route through the new error-handling path, which succeeded.  
- Performed a repository diff and inspected modified source lines to confirm the new exception-to-JSON-RPC mappings and `initialize` capability change, which succeeded.  
- Attempted to build `src/VsIdeBridgeCli/VsIdeBridgeCli.csproj` with `dotnet`, but the environment lacks `dotnet` so the build could not be executed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78365051c832d8344242b93b97fce)